### PR TITLE
Allow specifying multiple supervisor processes

### DIFF
--- a/.github/workflows/install-hadoop.sh
+++ b/.github/workflows/install-hadoop.sh
@@ -9,7 +9,7 @@ sudo npm uninstall -g yarn || true
 
 sudo apt-get install -yq ssh rsync
 
-VERSION=3.3.1
+VERSION=2.10.1
 HADOOP_URL="https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=hadoop/common/hadoop-$VERSION/hadoop-$VERSION.tar.gz"
 
 # download hadoop

--- a/mars/deploy/oscar/ray.py
+++ b/mars/deploy/oscar/ray.py
@@ -304,8 +304,17 @@ async def new_cluster(
     ensure_isolation_created(kwargs)
     if kwargs:  # pragma: no cover
         raise TypeError(f"new_cluster got unexpected " f"arguments: {list(kwargs)}")
+    n_supervisor_process = kwargs.get(
+        "n_supervisor_process", DEFAULT_SUPERVISOR_SUB_POOL_NUM
+    )
     cluster = RayCluster(
-        cluster_name, supervisor_mem, worker_num, worker_cpu, worker_mem, config
+        cluster_name,
+        supervisor_mem,
+        worker_num,
+        worker_cpu,
+        worker_mem,
+        config,
+        n_supervisor_process=n_supervisor_process,
     )
     try:
         await cluster.start()
@@ -371,11 +380,13 @@ class RayCluster:
         worker_cpu: int = 16,
         worker_mem: int = 32 * 1024 ** 3,
         config: Union[str, Dict] = None,
+        n_supervisor_process: int = DEFAULT_SUPERVISOR_SUB_POOL_NUM,
     ):
         # load third party extensions.
         init_extension_entrypoints()
         self._cluster_name = cluster_name
         self._supervisor_mem = supervisor_mem
+        self._n_supervisor_process = n_supervisor_process
         self._worker_num = worker_num
         self._worker_cpu = worker_cpu
         self._worker_mem = worker_mem
@@ -402,7 +413,7 @@ class RayCluster:
             self._config.get("cluster", {})
             .get("ray", {})
             .get("supervisor", {})
-            .get("sub_pool_num", DEFAULT_SUPERVISOR_SUB_POOL_NUM)
+            .get("sub_pool_num", self._n_supervisor_process)
         )
         from ...storage.ray import support_specify_owner
 

--- a/mars/deploy/oscar/session.py
+++ b/mars/deploy/oscar/session.py
@@ -1715,7 +1715,10 @@ async def _execute(
                         break
                     except asyncio.TimeoutError:
                         # timeout
-                        if not cancelled.is_set():
+                        if (
+                            not cancelled.is_set()
+                            and execution_info.progress() is not None
+                        ):
                             progress_bar.update(execution_info.progress() * 100)
                 if cancelled.is_set():
                     # cancel execution

--- a/mars/deploy/oscar/supervisor.py
+++ b/mars/deploy/oscar/supervisor.py
@@ -32,6 +32,9 @@ class SupervisorCommandRunner(OscarCommandRunner):
     def config_args(self, parser):
         super().config_args(parser)
         parser.add_argument("-w", "--web-port", help="web port of the service")
+        parser.add_argument(
+            "--n-process", help="number of supervisor processes", default="0"
+        )
 
     def parse_args(self, parser, argv, environ=None):
         args = super().parse_args(parser, argv, environ=environ)
@@ -52,7 +55,7 @@ class SupervisorCommandRunner(OscarCommandRunner):
     async def create_actor_pool(self):
         return await create_supervisor_actor_pool(
             self.args.endpoint,
-            n_process=0,
+            n_process=int(self.args.n_process),
             ports=self.ports,
             modules=self.args.load_modules,
             logging_conf=self.logging_conf,

--- a/mars/deploy/oscar/tests/test_cmdline.py
+++ b/mars/deploy/oscar/tests/test_cmdline.py
@@ -103,7 +103,7 @@ def _get_labelled_port(label=None, create=True):
     test_name = os.environ["PYTEST_CURRENT_TEST"]
     if (test_name, label) not in _test_port_cache:
         if create:
-            _test_port_cache[(test_name, label)] = get_next_port()
+            _test_port_cache[(test_name, label)] = get_next_port(occupy=True)
         else:
             return None
     return _test_port_cache[(test_name, label)]
@@ -128,6 +128,8 @@ start_params = {
             lambda: f'127.0.0.1:{_get_labelled_port("supervisor")}',
             "-w",
             lambda: str(_get_labelled_port("web")),
+            "--n-process",
+            "2",
         ],
         worker_cmd_start
         + [

--- a/mars/oscar/backends/core.py
+++ b/mars/oscar/backends/core.py
@@ -66,6 +66,8 @@ class ActorCaller:
                 self._client_to_message_futures[client] = dict()
                 for future in message_futures.values():
                     future.set_exception(e)
+            finally:
+                await asyncio.sleep(0)
 
         message_futures = self._client_to_message_futures.get(client)
         self._client_to_message_futures[client] = dict()

--- a/mars/oscar/backends/message.py
+++ b/mars/oscar/backends/message.py
@@ -59,6 +59,7 @@ class ControlMessageType(Enum):
     sync_config = 2
     get_config = 3
     wait_pool_recovered = 4
+    add_sub_pool_actor = 5
 
 
 @dataslots
@@ -192,7 +193,14 @@ class ErrorMessage(_MessageBase):
 
 
 class CreateActorMessage(_MessageBase):
-    __slots__ = "actor_cls", "actor_id", "args", "kwargs", "allocate_strategy"
+    __slots__ = (
+        "actor_cls",
+        "actor_id",
+        "args",
+        "kwargs",
+        "allocate_strategy",
+        "from_main",
+    )
 
     def __init__(
         self,
@@ -202,6 +210,7 @@ class CreateActorMessage(_MessageBase):
         args: Tuple,
         kwargs: Dict,
         allocate_strategy,
+        from_main: bool = False,
         protocol: int = None,
         message_trace: List[MessageTraceItem] = None,
     ):
@@ -211,6 +220,7 @@ class CreateActorMessage(_MessageBase):
         self.args = args
         self.kwargs = kwargs
         self.allocate_strategy = allocate_strategy
+        self.from_main = from_main
 
     @classproperty
     @implements(_MessageBase.message_type)

--- a/mars/services/cluster/api/oscar.py
+++ b/mars/services/cluster/api/oscar.py
@@ -82,8 +82,6 @@ class ClusterAPI(AbstractClusterAPI):
         ----------
         keys
             key for a supervisor address
-        watch
-            if True, will watch changes of supervisor changes
 
         Returns
         -------

--- a/mars/services/lifecycle/api/web.py
+++ b/mars/services/lifecycle/api/web.py
@@ -14,7 +14,6 @@
 
 from typing import Dict, List
 
-from ....lib.aio import alru_cache
 from ....utils import serialize_serializable, deserialize_serializable
 from ...web import web_api, MarsServiceWebAPIHandler, MarsWebAPIClientMixin
 from .core import AbstractLifecycleAPI
@@ -23,19 +22,10 @@ from .core import AbstractLifecycleAPI
 class LifecycleWebAPIHandler(MarsServiceWebAPIHandler):
     _root_pattern = "/api/session/(?P<session_id>[^/]+)/lifecycle"
 
-    @alru_cache(cache_exceptions=False)
-    async def _get_cluster_api(self):
-        from ...cluster import ClusterAPI
-
-        return await ClusterAPI.create(self._supervisor_addr)
-
-    @alru_cache(cache_exceptions=False)
     async def _get_oscar_lifecycle_api(self, session_id: str):
         from .oscar import LifecycleAPI
 
-        cluster_api = await self._get_cluster_api()
-        [address] = await cluster_api.get_supervisors_by_keys([session_id])
-        return await LifecycleAPI.create(session_id, address)
+        return await self._get_api_by_key(LifecycleAPI, session_id)
 
     @web_api("", method="post", arg_filter={"action": "decref_tileables"})
     async def decref_tileables(self, session_id: str):

--- a/mars/services/meta/api/web.py
+++ b/mars/services/meta/api/web.py
@@ -15,7 +15,6 @@
 from typing import Dict, List, Optional
 
 from .... import oscar as mo
-from ....lib.aio import alru_cache
 from ....utils import serialize_serializable, deserialize_serializable
 from ...web import web_api, MarsServiceWebAPIHandler, MarsWebAPIClientMixin
 from .core import AbstractMetaAPI
@@ -24,19 +23,10 @@ from .core import AbstractMetaAPI
 class MetaWebAPIHandler(MarsServiceWebAPIHandler):
     _root_pattern = "/api/session/(?P<session_id>[^/]+)/meta"
 
-    @alru_cache(cache_exceptions=False)
-    async def _get_cluster_api(self):
-        from ...cluster import ClusterAPI
-
-        return await ClusterAPI.create(self._supervisor_addr)
-
-    @alru_cache(cache_exceptions=False)
     async def _get_oscar_meta_api(self, session_id: str):
         from .oscar import MetaAPI
 
-        cluster_api = await self._get_cluster_api()
-        [address] = await cluster_api.get_supervisors_by_keys([session_id])
-        return await MetaAPI.create(session_id, address)
+        return await self._get_api_by_key(MetaAPI, session_id)
 
     @web_api("(?P<data_key>[^/]+)", method="get")
     async def get_chunk_meta(self, session_id: str, data_key: str):

--- a/mars/services/session/api/web.py
+++ b/mars/services/session/api/web.py
@@ -15,7 +15,6 @@
 import json
 from typing import Dict, List, Union
 
-from ....lib.aio import alru_cache
 from ....utils import parse_readable_size
 from ...web import web_api, MarsServiceWebAPIHandler, MarsWebAPIClientMixin
 from ..core import SessionInfo
@@ -46,19 +45,10 @@ def _decode_size(encoded: str) -> Union[int, str, Dict[str, Union[int, List[int]
 
 
 class SessionWebAPIBaseHandler(MarsServiceWebAPIHandler):
-    @alru_cache(cache_exceptions=False)
-    async def _get_cluster_api(self):
-        from ...cluster import ClusterAPI
-
-        return await ClusterAPI.create(self._supervisor_addr)
-
-    @alru_cache(cache_exceptions=False)
     async def _get_oscar_session_api(self):
         from .oscar import SessionAPI
 
-        cluster_api = await self._get_cluster_api()
-        [address] = await cluster_api.get_supervisors_by_keys(["Session"])
-        return await SessionAPI.create(address)
+        return await self._get_api_by_key(SessionAPI, "Session", with_key_arg=False)
 
 
 class SessionWebAPIHandler(SessionWebAPIBaseHandler):

--- a/mars/services/storage/api/web.py
+++ b/mars/services/storage/api/web.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 from typing import Any, List
 
 from .... import oscar as mo
-from ....lib.aio import alru_cache
 from ....storage import StorageLevel
 from ....utils import serialize_serializable, deserialize_serializable
 from ...web import web_api, MarsServiceWebAPIHandler, MarsWebAPIClientMixin
@@ -27,19 +26,10 @@ from .core import AbstractStorageAPI
 class StorageWebAPIHandler(MarsServiceWebAPIHandler):
     _root_pattern = "/api/session/(?P<session_id>[^/]+)/storage"
 
-    @alru_cache(cache_exceptions=False)
-    async def _get_cluster_api(self):
-        from ...cluster import ClusterAPI
-
-        return await ClusterAPI.create(self._supervisor_addr)
-
-    @alru_cache(cache_exceptions=False)
     async def _get_oscar_meta_api(self, session_id: str):
         from ...meta import MetaAPI
 
-        cluster_api = await self._get_cluster_api()
-        [address] = await cluster_api.get_supervisors_by_keys([session_id])
-        return await MetaAPI.create(session_id, address)
+        return await self._get_api_by_key(MetaAPI, session_id)
 
     async def _get_storage_api_by_object_id(self, session_id: str, object_id: str):
         from .oscar import StorageAPI

--- a/mars/services/subtask/worker/runner.py
+++ b/mars/services/subtask/worker/runner.py
@@ -94,16 +94,24 @@ class SubtaskRunnerActor(mo.Actor):
         session_id = subtask.session_id
         supervisor_address = await self._get_supervisor_address(session_id)
         if session_id not in self._session_id_to_processors:
-            self._session_id_to_processors[session_id] = await mo.create_actor(
-                SubtaskProcessorActor,
-                session_id,
-                self._band,
-                supervisor_address,
-                self._worker_address,
-                self._subtask_processor_cls,
-                uid=SubtaskProcessorActor.gen_uid(session_id),
-                address=self.address,
-            )
+            try:
+                self._session_id_to_processors[session_id] = await mo.create_actor(
+                    SubtaskProcessorActor,
+                    session_id,
+                    self._band,
+                    supervisor_address,
+                    self._worker_address,
+                    self._subtask_processor_cls,
+                    uid=SubtaskProcessorActor.gen_uid(session_id),
+                    address=self.address,
+                )
+            except mo.ActorAlreadyExist:
+                # when recovering actor pools, the actor created in sub pools
+                # may be recovered already
+                self._session_id_to_processors[session_id] = await mo.actor_ref(
+                    uid=SubtaskProcessorActor.gen_uid(session_id),
+                    address=self.address,
+                )
         processor = self._session_id_to_processors[session_id]
         self._running_processor = self._last_processor = processor
         try:

--- a/mars/services/web/ui/package-lock.json
+++ b/mars/services/web/ui/package-lock.json
@@ -2261,9 +2261,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -9200,9 +9200,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {


### PR DESCRIPTION
As loops of supervisors may be blocked by GIL, it is possible to use another process to handle sessions in separate processes. As it may bring serialization overhead, we offer it as an option.

(though as a partial solution)